### PR TITLE
Update README.md - “i/o timeout”

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ export ELEVENLABS_TTS_KEY=<your_elevanlabs_tts_key>
 # agent is ready to start on port 8080
 make run-server
 ```
+To accelerate downloading Go dependencies and building projects on Ubuntu servers, you can try using Go Module Mirror：
+```bash
+export GOPROXY=https://goproxy.cn,direct
+```
 
 🎉 Congratulations! You have created your first personalized voice agent.
 


### PR DESCRIPTION
下载 Go 依赖包并构建项目常常会因为速度过慢而报错“i/o timeout”后终止，可以可以设置环境变量 GOPROXY 使用 Go 官方提供的代理来加速下载过程