### PR TITLE
Fix: check if go extensions have duplicated go module name

### DIFF
--- a/agents/scripts/build/main.go
+++ b/agents/scripts/build/main.go
@@ -1060,6 +1060,10 @@ func (ab *AppBuilder) autoDetectExtensions() error {
 		return err
 	}
 
+	// Ensure that all extension modules are unique, otherwise the modules with
+	// same name will be overwritten.
+	uniqueModules := make(map[string]string)
+
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -1076,6 +1080,16 @@ func (ab *AppBuilder) autoDetectExtensions() error {
 			continue
 		}
 
+		if location, ok := uniqueModules[ext.module]; ok {
+			return fmt.Errorf(
+				"the extensions [%s] and [%s] have duplicated module name [%s]",
+				path.Base(location),
+				path.Base(ext.location),
+				ext.module,
+			)
+		}
+
+		uniqueModules[ext.module] = ext.location
 		ab.extensions = append(ab.extensions, ext)
 	}
 

--- a/agents/scripts/install_deps_and_build.sh
+++ b/agents/scripts/install_deps_and_build.sh
@@ -65,6 +65,10 @@ build_go_app() {
   cd $app_dir
 
   go run scripts/build/main.go --verbose
+  if [[ $? -ne 0 ]]; then
+    echo "FATAL: failed to build go app, see logs for detail."
+    exit 1
+  fi
 }
 
 clean() {


### PR DESCRIPTION
Example of error message:

```text
02:30:12 Error: auto detect extensions failed. Root cause: 
	the extensions [elevenlabs_tts] and [interrupt_detector] have duplicated module name [extension]
exit status 1
FATAL: failed to build go app, see logs for detail.
make: *** [Makefile:11: build-agents] Error 1
```